### PR TITLE
fix(api): Improve error handling for giveaways endpoint

### DIFF
--- a/src/app/api/giveaways/route.ts
+++ b/src/app/api/giveaways/route.ts
@@ -199,12 +199,18 @@ async function handleGiveawaysList(searchParams: URLSearchParams) {
   } catch (error) {
     console.error('Giveaways API Error:', error);
 
-    // Return empty array instead of error for better UX
-    return NextResponse.json([], {
-      status: 200,
-      headers: {
-        'Cache-Control': 'no-cache',
+    const errorMessage =
+      error instanceof Error ? error.message : 'An unknown error occurred';
+
+    // Return a proper error response
+    return NextResponse.json(
+      { message: `Failed to fetch giveaways: ${errorMessage}` },
+      {
+        status: 500,
+        headers: {
+          'Cache-Control': 'no-cache',
+        },
       },
-    });
+    );
   }
 }


### PR DESCRIPTION
The giveaways API endpoint at `/api/giveaways` would previously return an empty array with a 200 OK status when it failed to fetch data from the external GamerPower API. This was misleading for the client, as it would appear as if there were no giveaways rather than an error.

This commit changes the behavior to return a 500 Internal Server Error with a JSON payload containing a descriptive error message. This allows the frontend to properly handle the error and display an informative message to the user.